### PR TITLE
Update pytest to latest version, remove unnecessary dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,4 @@
-attrs==21.2.0
-iniconfig==1.1.1
-packaging==20.9
-pluggy==0.13.1
-py==1.11.0
-pyparsing==2.4.7
-pytest==7.2.2
-toml==0.10.2
+iniconfig==2.0.0
+packaging==23.1
+pluggy==1.3.0
+pytest==7.4.2


### PR DESCRIPTION
Update to latest version of pytest (7.4.2).

- Solution branch for testing: https://github.com/AdaGold/school_schedule/tree/kelsey_solution_updated_pytest
- When we've merged in the changes, I plan to remove the solution branches from this repo in favor of the AdaAnswers repo: https://github.com/AdaAnswers/school_schedule